### PR TITLE
Add configuration of env vars

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,8 @@ impl ConfigFile {
 pub struct SpotifyConfig {
     #[serde(default)]
     pub extra_arguments: Vec<String>,
+    #[serde(default)]
+    pub extra_env_vars: Vec<String>,
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,13 @@ fn start(args: &Args, cf: &ConfigFile, install_path: &Path) -> Result<()> {
     if args.no_exec {
         info!("Skipping exec because --no-exec was used");
     } else {
+        cf.spotify.extra_env_vars.iter().for_each(|x| {
+            let (k, v) = match x.split_once('=') {
+                None => (x.as_str(), ""),
+                Some(x) => x,
+            };
+            std::env::set_var(k, v);
+        });
         nix::unistd::execv(&bin, &exec_args)
             .with_context(|| anyhow!("Failed to exec {:?}", bin))?;
     }


### PR DESCRIPTION
This PR adds configuring environment variables in the config file, which is useful for specifying `LD_PRELOAD` for using e.g. https://github.com/dasJ/spotifywm.

It allows specifying `extra_env_vars = ["K1=V1", "K2=V2" ]` and calls `set_var`  before the `execv`. However, I'd like your feedback on whether this approach or using `execve` would be better.