### PR TITLE
Add support for opening URIs in existing instance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ env_logger = "0.10"
 libflate = "1.2.0"
 log = "0.4.17"
 nix = { version = "0.26", default-features = false, features = ["process"] }
+regex = "1.7.3"
 reqwest = "0.11.10"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ tempfile = "3.3.0"
 tokio = { version = "1.18.1", features = ["macros", "rt-multi-thread", "process", "time", "fs"] }
 toml = "0.5.9"
 xch = "1.1.0"
+zbus = "3.10.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,8 @@ pub struct SpotifyConfig {
     pub extra_arguments: Vec<String>,
     #[serde(default)]
     pub extra_env_vars: Vec<String>,
+    #[serde(default)]
+    pub disable_dbus: bool,
 }
 
 #[cfg(test)]

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -18,11 +18,36 @@ pub fn is_spotify_running() -> bool {
     }
 }
 
+fn parse_uri(uri: &String) -> Result<String> {
+    // Remove useless tracking IDs
+    let sanitized_uri = Regex::new(r"\?.*").unwrap().replace_all(uri, "");
+
+    // URIs may be of one of the following forms:
+    // 1. spotify:type:id
+    // 2. spotify://type/id
+    //
+    // Here type must be something like "track" or "album"
+    // and id is a unique id consisting of alphanumerical symbols.
+    //
+    // The dbus interface only understands the first syntax,
+    // so we have to transform the second scheme into the first one.
+    let r = Regex::new(r"^spotify:(?://)?(?P<type>[a-z]+)(?::|/)(?P<id>[[:alnum:]]+)$").unwrap();
+    match r.captures(&sanitized_uri) {
+        Some(c) => Ok(format!(
+            "spotify:{}:{}",
+            c.name("type").unwrap().as_str(),
+            c.name("id").unwrap().as_str()
+        )),
+        None => Err(zbus::Error::Failure(
+            "Unsupported URI scheme for dbus".to_string(),
+        )),
+    }
+}
+
 pub fn play_remote(uri: &String) -> Result<Arc<zbus::Message>> {
     info!("Playing uri {uri} in already running instance over dbus");
     let c = zbus::blocking::Connection::session()?;
-    // Remove useless tracking IDs
-    let sanitized_uri = Regex::new(r"\?.*").unwrap().replace_all(uri, "");
+    let parsed = parse_uri(uri)?;
     // This dbus interface supports URIs in the spotify:<type>:<UUID> format,
     // which conveniently is also the format used by the "--uri" arg
     c.call_method(
@@ -30,6 +55,6 @@ pub fn play_remote(uri: &String) -> Result<Arc<zbus::Message>> {
         "/org/mpris/MediaPlayer2",
         Some("org.mpris.MediaPlayer2.Player"),
         "OpenUri",
-        &(sanitized_uri),
+        &(parsed),
     )
 }

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -1,4 +1,5 @@
 use log::info;
+use regex::Regex;
 use std::sync::Arc;
 use zbus::Result;
 
@@ -20,6 +21,8 @@ pub fn is_spotify_running() -> bool {
 pub fn play_remote(uri: &String) -> Result<Arc<zbus::Message>> {
     info!("Playing uri {uri} in already running instance over dbus");
     let c = zbus::blocking::Connection::session()?;
+    // Remove useless tracking IDs
+    let sanitized_uri = Regex::new(r"\?.*").unwrap().replace_all(uri, "");
     // This dbus interface supports URIs in the spotify:<type>:<UUID> format,
     // which conveniently is also the format used by the "--uri" arg
     c.call_method(
@@ -27,6 +30,6 @@ pub fn play_remote(uri: &String) -> Result<Arc<zbus::Message>> {
         "/org/mpris/MediaPlayer2",
         Some("org.mpris.MediaPlayer2.Player"),
         "OpenUri",
-        &(uri),
+        &(sanitized_uri),
     )
 }

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -25,13 +25,17 @@ fn parse_uri(uri: &String) -> Result<String> {
     // URIs may be of one of the following forms:
     // 1. spotify:type:id
     // 2. spotify://type/id
+    // 3. https://open.spotify.com/type/id
     //
     // Here type must be something like "track" or "album"
     // and id is a unique id consisting of alphanumerical symbols.
     //
     // The dbus interface only understands the first syntax,
-    // so we have to transform the second scheme into the first one.
-    let r = Regex::new(r"^spotify:(?://)?(?P<type>[a-z]+)(?::|/)(?P<id>[[:alnum:]]+)$").unwrap();
+    // so we have to transform the other schemes into the first scheme.
+    //
+    // We employ a very strict Regex here, so that we never mistakenly pass a wrong URI over dbus by accident.
+    // If the Regex doesn't match, it is better to bail out and open Spotify normally.
+    let r = Regex::new(r"^(?:spotify|https):(?://(?:open\.spotify\.com/)?)?(?P<type>[a-z]+)(?::|/)(?P<id>[[:alnum:]]+)$").unwrap();
     match r.captures(&sanitized_uri) {
         Some(c) => Ok(format!(
             "spotify:{}:{}",

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -63,3 +63,51 @@ pub fn play_remote(uri: &String) -> Result<Arc<zbus::Message>> {
         &(parsed),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_internal_scheme() -> Result<()> {
+        let u = parse_uri(&"spotify:track:5GJaxfibCRCQXDVPgHJv0s?si=43a3210a84c340dc".to_string())?;
+        assert_eq!(u, "spotify:track:5GJaxfibCRCQXDVPgHJv0s");
+        Ok(())
+    }
+
+    #[test]
+    fn test_xdg_open_scheme() -> Result<()> {
+        let u =
+            parse_uri(&"spotify://track/5GJaxfibCRCQXDVPgHJv0s?si=43a3210a84c340dc".to_string())?;
+        assert_eq!(u, "spotify:track:5GJaxfibCRCQXDVPgHJv0s");
+        Ok(())
+    }
+
+    #[test]
+    fn test_https_scheme() -> Result<()> {
+        let u = parse_uri(
+            &"https://open.spotify.com/track/5GJaxfibCRCQXDVPgHJv0s?si=43a3210a84c340dc"
+                .to_string(),
+        )?;
+        assert_eq!(u, "spotify:track:5GJaxfibCRCQXDVPgHJv0s");
+        Ok(())
+    }
+
+    #[test]
+    fn test_passthrough_wrong_type() -> Result<()> {
+        assert!(parse_uri(
+            &"spotify://invalid/5GJaxfibCRCQXDVPgHJv0s?si=43a3210a84c340dc".to_string()
+        )
+        .is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_passthrough_wrong_scheme() -> Result<()> {
+        assert!(parse_uri(
+            &"invalid://track/5GJaxfibCRCQXDVPgHJv0s?si=43a3210a84c340dc".to_string()
+        )
+        .is_err());
+        Ok(())
+    }
+}

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -29,13 +29,14 @@ fn parse_uri(uri: &String) -> Result<String> {
     //
     // Here type must be something like "track" or "album"
     // and id is a unique id consisting of alphanumerical symbols.
+    // Also see: https://www.iana.org/assignments/uri-schemes/prov/spotify
     //
     // The dbus interface only understands the first syntax,
     // so we have to transform the other schemes into the first scheme.
     //
     // We employ a very strict Regex here, so that we never mistakenly pass a wrong URI over dbus by accident.
     // If the Regex doesn't match, it is better to bail out and open Spotify normally.
-    let r = Regex::new(r"^(?:spotify|https):(?://(?:open\.spotify\.com/)?)?(?P<type>[a-z]+)(?::|/)(?P<id>[[:alnum:]]+)$").unwrap();
+    let r = Regex::new(r"^(?:spotify|https):(?://(?:open\.spotify\.com/)?)?(?P<type>(?:artist|album|track|search))(?::|/)(?P<id>[[:alnum:]]+)$").unwrap();
     match r.captures(&sanitized_uri) {
         Some(c) => Ok(format!(
             "spotify:{}:{}",

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -1,0 +1,32 @@
+use log::info;
+use std::sync::Arc;
+use zbus::Result;
+
+pub fn is_spotify_running() -> bool {
+    match zbus::blocking::Connection::session() {
+        Ok(c) => c
+            .call_method(
+                Some("org.mpris.MediaPlayer2.spotify"),
+                "/org/mpris/MediaPlayer2",
+                Some("org.freedesktop.DBus.Peer"),
+                "Ping",
+                &(),
+            )
+            .is_ok(),
+        _ => false,
+    }
+}
+
+pub fn play_remote(uri: &String) -> Result<Arc<zbus::Message>> {
+    info!("Playing uri {uri} in already running instance over dbus");
+    let c = zbus::blocking::Connection::session()?;
+    // This dbus interface supports URIs in the spotify:<type>:<UUID> format,
+    // which conveniently is also the format used by the "--uri" arg
+    c.call_method(
+        Some("org.mpris.MediaPlayer2.spotify"),
+        "/org/mpris/MediaPlayer2",
+        Some("org.mpris.MediaPlayer2.Player"),
+        "OpenUri",
+        &(uri),
+    )
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod apt;
 pub mod args;
 pub mod config;
 pub mod crypto;
+pub mod dbus;
 pub mod deb;
 pub mod errors;
 pub mod extract;

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,7 +162,7 @@ async fn main() -> Result<()> {
         // First check if Spotify is already running and
         // try to open this URI in the existing Spotify instance over dbus.
         // If this fails, we will fallback to starting a new Spotify instance.
-        if args.uri.is_some() && is_spotify_running() {
+        if !cf.spotify.disable_dbus && args.uri.is_some() && is_spotify_running() {
             match play_remote(args.uri.as_ref().unwrap()) {
                 Ok(_) => return Ok(()),
                 Err(e) => warn!("Failed to connect to existing Spotify instance: {e}"),


### PR DESCRIPTION
Right now if we open Spotify URLs (for example via Spotify Web -> "Open in Desktop App"), it will always open a new Spotify instance, even if there is already one running and playing music already.

This patch uses Spotify's `org.mpris.MediaPlayer2.Player.OpenUri` dbus method to open the link in the existing instance instead.

If this dbus call fails for whatever reason, it falls back to opening a new instance (like the old behaviour).
Obviously we also first check if an instance already exists, before attempting to call `OpenUri`.

## Demo

https://github.com/vimpostor/blog/assets/21310755/5443f4d4-aec2-401f-971d-e8b73c2a1788