### PR TITLE
fix: add spotify launcher arguments into config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ If no config is found it's going to start with default settings. Your configurat
 #extra_arguments = ["--force-device-scale-factor=2.0"]
 ## On wayland you might need
 #extra_arguments = ["--enable-features=UseOzonePlatform", "--ozone-platform=wayland"]
+[launcher]
+## Skip update (override check_update option)
+#skip_update = true
+## Force update (override check_update = true and skip_update = false)
+#force_update = true
+## Check update
+#check_update = true
 ```
 
 ## License

--- a/contrib/spotify-launcher.conf
+++ b/contrib/spotify-launcher.conf
@@ -8,3 +8,10 @@
 #extra_arguments = ["--enable-features=UseOzonePlatform", "--ozone-platform=wayland"]
 ## How often to try to resume the download until giving up (0 for unlimited)
 #download_attempts = 5
+[launcher]
+## Skip update (override check_update option)
+#skip_update = true
+## Force update (override check_update = true and skip_update = false)
+#force_update = true
+## Check update
+#check_update = true


### PR DESCRIPTION
I need to remove Spotify updates. I can't set this in the file configuration. I have to modify the .desktop file and pass it the `--skip-update` argument. I thought it might be useful to add these options to the configuration file.