### PR TITLE
Add support for data.tar.xz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,6 +723,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1174,7 @@ dependencies = [
  "tokio",
  "toml",
  "xch",
+ "xz2",
 ]
 
 [[package]]
@@ -1748,6 +1760,15 @@ dependencies = [
  "errno 0.2.8",
  "uuid",
  "winapi",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ tempfile = "3.3.0"
 tokio = { version = "1.18.1", features = ["macros", "rt-multi-thread", "process", "time", "fs"] }
 toml = "0.8"
 xch = "1.1.0"
+xz2 = "0.1.7"


### PR DESCRIPTION
Seems the upstream deb switched from tar.gz to tar.xz

Seems to handle the tar.xz fine once it is decompressed