### PR TITLE
fix: use rusts-lzma to decompress .xz archives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,6 +994,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
+name = "rust-lzma"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d62915608f6cee1d7f2fc00f28b4f058ff79d6e4ec3c2fe0006b09b52437c84"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,6 +1165,7 @@ dependencies = [
  "log",
  "nix",
  "reqwest",
+ "rust-lzma",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ libflate = "2"
 log = "0.4.17"
 nix = { version = "0.27", default-features = false, features = ["process"] }
 reqwest = "0.11.10"
+rust-lzma = "0.6.0"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 sha2 = "0.10.2"


### PR DESCRIPTION
This builds upon #53 . I apologize if there was a way to contribute directly to that PR but I couldn't figure it out.

I tried using `lzma-rs` since it seems to be a lot more popular, but for some reason I don't understand, the `xz_decompress` method was taking over a minute to finish.

For clarity sake, this is the code I had with `lzma-rs`:
```rs
let mut buf = std::io::BufReader::new(&mut entry);
let mut decomp: Vec<u8> = Vec::new();
lzma_rs::xz_decompress(&mut buf, &mut decomp).unwrap();
let tar = tar::Archive::new(&decomp[..]);
return extract_data(tar, args, install_path).await;
```

Since I couldn't figure out what went wrong, I switched to rust-lzma instead