### PR TITLE
Allow signal handling when running from CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
+dependencies = [
+ "nix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "dary_heap"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,6 +1433,7 @@ dependencies = [
  "ar",
  "bytes",
  "clap",
+ "ctrlc",
  "dirs",
  "env_logger",
  "libflate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.57"
 ar = "0.9.0"
 bytes = "1.1.0"
 clap = { version = "4", features = ["derive"] }
+ctrlc = "3.4.5"
 dirs = "5"
 env_logger = "0.11"
 libflate = "2"


### PR DESCRIPTION
This PR introduces a new structure when running the Spotify child process, allowing signal handling when running from the command line. This commit specifically adds the feature to properly exit when issuing a SIGINT (Ctrl+C) from the command line.

This PR resolves #63.

Any suggestions to simplify and/or improve this code are welcome.